### PR TITLE
feat(popupSchoolYear): MVS-36 add popup confirmation for setting school year

### DIFF
--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -486,6 +486,7 @@
   "viescolaire.utils.no": "Non",
   "viescolaire.utils.students": "Élèves",
   "viescolaire.utils.name": "Nom",
+  "viescolaire.utils.confirm": "Confirmer",
   "viescolaire.param": "Paramétrages",
   "viescolaire.categorie": "Catégorie",
   "viescolaire.categorie.edit": "Modifier la catégorie",
@@ -810,5 +811,6 @@
   "viescolaire.conference.elements": "Éléments du programme",
   "viescolaire.service.warning.classesNonEvaluables" : "Vous ne pouvez pas sélectionner de services non-évaluables : ",
   "viescolaire.service.error.student": "Erreur lors de la récupération des élèves.",
-  "evaluation.orderShowSubject.title": "Organiser les matières"
+  "evaluation.orderShowSubject.title": "Organiser les matières",
+  "viescolaire.confirmation.updateSchoolYear": "Êtes-vous sûrs de vouloir changer les dates de l'année scolaire ? Des modules pourraient être impactés par ce changement."
 }

--- a/src/main/resources/public/modules/viescolaire/controllers/vsco_periodeAnnee_ctrl.ts
+++ b/src/main/resources/public/modules/viescolaire/controllers/vsco_periodeAnnee_ctrl.ts
@@ -10,6 +10,10 @@ export const periodeAnneeController = ng.controller('periodeAnneeController', [
         $scope.notifications = [];
         $scope.periodeAnnee = new PeriodeAnnee($scope.structure.id);
 
+        $scope.opened = {
+            lightboxUpdateSchoolYear: false
+        }
+
         $scope.periodeAnnee.sync().then((res) => {
             if ($scope.periodeAnnee.id) {
                 $scope.periodeAnnee.setIsExist(true);
@@ -34,9 +38,19 @@ export const periodeAnneeController = ng.controller('periodeAnneeController', [
             }
         };
 
+        $scope.confirmUpdateSchoolYear = () => {
+            $scope.opened.lightboxUpdateSchoolYear = true;
+            utils.safeApply($scope);
+        }
+
+        $scope.cancelUpdateSchoolYear = () => {
+            $scope.opened.lightboxUpdateSchoolYear = false;
+        }
+
         $scope.createPeriodeAnnee = async () => {
             $scope.periodeAnnee.setIsOpening(true);
             $scope.toastHttpCall(await $scope.periodeAnnee.save());
+            $scope.opened.lightboxUpdateSchoolYear = false;
         }
     }
 ]);

--- a/src/main/resources/public/sass/global/specifics/_viescolaire.scss
+++ b/src/main/resources/public/sass/global/specifics/_viescolaire.scss
@@ -525,4 +525,13 @@ body.viescolaire {
     max-height: fit-content;
   }
 
+  .lightbox-update-school-year {
+    .content {
+      width: 540px;
+    }
+    .button-margin {
+      margin-top: 2em;
+    }
+  }
+
 }

--- a/src/main/resources/public/templates/viescolaire/param_etab_items/param_annee_scolaire.html
+++ b/src/main/resources/public/templates/viescolaire/param_etab_items/param_annee_scolaire.html
@@ -31,7 +31,7 @@
             </button>
             <button ng-if="periodeAnnee.isExist"
                     class="right-magnet"
-                    ng-click="createPeriodeAnnee()"
+                    ng-click="confirmUpdateSchoolYear()"
                     ng-disabled="!isValidForm()">
                 <span class="no-style ng-scope"><i18n>item.modify</i18n></span>
             </button>
@@ -39,4 +39,23 @@
 
     </article>
 
+    <lightbox class="lightbox-update-school-year" show="opened.lightboxUpdateSchoolYear" on-close="opened.lightboxUpdateSchoolYear = false" >
+        <div class="twelve row content">
+            <h3>
+                <i18n>viescolaire.year.set</i18n>
+            </h3>
+
+            <p>
+                <i18n>viescolaire.confirmation.updateSchoolYear</i18n>
+            </p>
+            <div class="right-magnet button-margin">
+                <button class="marginFive" ng-click="createPeriodeAnnee()">
+                    <i18n>viescolaire.utils.confirm</i18n>
+                </button>
+                <button class="marginFive cancel" ng-click="cancelUpdateSchoolYear()">
+                    <i18n>viescolaire.utils.cancel</i18n>
+                </button>
+            </div>
+        </div>
+    </lightbox>
 </div>


### PR DESCRIPTION
## Describe your changes
Adding a confirmation popup when user want to setting up school year.

![image](https://user-images.githubusercontent.com/69917847/173772748-d3f841f2-5ef5-4590-a9d3-a51d3f423b79.png)
## Checklist tests
- Popup appear when user want to save changes for school year period.
- Check if the period is correctly modify and save.
- No popup when user setting for the first time the school year period.
- Check if the period is correctly set
## Issue ticket number and link
MVS-36 : https://entsupport.gdapublic.fr/browse/MVS-36
## Checklist before requesting a review (magic string, indentation, comment/documentation...)
- Magic string
- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

