### PR TITLE
chore(test): fix test executed in build directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     ],
     "testPathIgnorePatterns": [
         "/node_modules/",
-        "<rootDir>/viescolaire/build/",
-        "<rootDir>/viescolaire/out/"
+        "<rootDir>/build/",
+        "<rootDir>/out/"
     ],
     "verbose": true,
     "testURL": "http://localhost/",


### PR DESCRIPTION
Le chemin d'accès du dossier build et out était mal indiquer pour l'exclusion des test Node.