### PR TITLE
fix(user-search): #MA-1076 retrieve all personnel on personnel search

### DIFF
--- a/src/main/java/fr/openent/viescolaire/service/impl/DefaultUserService.java
+++ b/src/main/java/fr/openent/viescolaire/service/impl/DefaultUserService.java
@@ -848,12 +848,20 @@ public class DefaultUserService extends SqlCrudService implements UserService {
         final StringBuilder filter = new StringBuilder();
         fields.forEach(field -> filter.append("OR toLower(").append(getFieldName(field)).append(") CONTAINS {query} "));
 
-        String neo4jquery = "MATCH (u:User)-[:IN]->(p:ProfileGroup)-[:DEPENDS*]->(s:Structure), (p)-[:DEPENDS]->(c:Class) " +
-                "WHERE s.id = {structureId} AND u.profiles = {profiles} " +
+        String neo4jquery = "MATCH (u:User)-[:IN]->(p:ProfileGroup)-[:DEPENDS*]->(s:Structure) ";
+
+        if (!Objects.equals(profile, "Personnel"))
+            neo4jquery += ",(p)-[:DEPENDS]->(c:Class) ";
+
+        neo4jquery += "WHERE s.id = {structureId} AND u.profiles = {profiles} " +
                 "AND (" + filter.toString().replaceFirst("OR ", "") + ") " +
                 "RETURN distinct u.id as id, (u.lastName + ' ' + u.firstName) as displayName, u.lastName as lastName," +
-                " u.firstName as firstName, u.classes as idClasse, collect(c.name) as classesNames " +
-                "ORDER BY displayName;";
+                " u.firstName as firstName, u.classes as idClasse ";
+
+        if (!Objects.equals(profile, "Personnel"))
+            neo4jquery += ",collect(c.name) as classesNames ";
+
+        neo4jquery += "ORDER BY displayName;";
 
 
         if (userId != null) {

--- a/src/test/java/fr/openent/viescolaire/service/impl/DefaultUserServiceTest.java
+++ b/src/test/java/fr/openent/viescolaire/service/impl/DefaultUserServiceTest.java
@@ -92,10 +92,10 @@ public class DefaultUserServiceTest {
     public void testSearchNullUserId(TestContext ctx) {
         Async async = ctx.async();
         List<String> fields = Arrays.asList("field1", "field2");
-        String expectedQuery = "MATCH (u:User)-[:IN]->(p:ProfileGroup)-[:DEPENDS*]->(s:Structure), (p)-[:DEPENDS]->(c:Class) WHERE s.id" +
+        String expectedQuery = "MATCH (u:User)-[:IN]->(p:ProfileGroup)-[:DEPENDS*]->(s:Structure) ,(p)-[:DEPENDS]->(c:Class) WHERE s.id" +
                 " = {structureId} AND u.profiles = {profiles} AND (toLower(u.displayName) CONTAINS {query} OR toLower(u.displayName)" +
                 " CONTAINS {query} ) RETURN distinct u.id as id, (u.lastName + ' ' + u.firstName) as displayName, u.lastName as lastName," +
-                " u.firstName as firstName, u.classes as idClasse, collect(c.name) as classesNames ORDER BY displayName;";
+                " u.firstName as firstName, u.classes as idClasse ,collect(c.name) as classesNames ORDER BY displayName;";
         String expectedParams = "{\"structureId\":\"structureId\",\"userId\":null,\"query\":\"query\",\"profiles\":[\"profile\"]}";
 
         Mockito.doAnswer((Answer<Void>) invocation -> {


### PR DESCRIPTION
## Describe your changes

- retrieve all personnel users on user search (if _profile="Personnel"_). The class dependency on personnel search has been removed.

## Checklist tests

- check if all personnel are fetched on search (ex: on create incident view, in Presences)
- check if all searches are working properly, even with restricted rights

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1076

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

