### PR TITLE
fix(security): #MVS-108 add new resourceFilter on route get /groupe/enseignement/users/:groupId in GroupeEnseignementController

### DIFF
--- a/src/main/java/fr/openent/Viescolaire.java
+++ b/src/main/java/fr/openent/Viescolaire.java
@@ -91,6 +91,7 @@ public class Viescolaire extends BaseServer {
 
 	@Override
     public void start() throws Exception {
+        DB.getInstance().init(Neo4j.getInstance(), Sql.getInstance(), MongoDb.getInstance());
         super.start();
 
         final EventBus eb = getEventBus(vertx);
@@ -103,7 +104,6 @@ public class Viescolaire extends BaseServer {
             throw new RuntimeException("no date in update-classes");
         }
 
-        DB.getInstance().init(Neo4j.getInstance(), Sql.getInstance(), MongoDb.getInstance());
 
         /*
 			DISPLAY CONTROLLER

--- a/src/main/java/fr/openent/Viescolaire.java
+++ b/src/main/java/fr/openent/Viescolaire.java
@@ -91,7 +91,6 @@ public class Viescolaire extends BaseServer {
 
 	@Override
     public void start() throws Exception {
-        DB.getInstance().init(Neo4j.getInstance(), Sql.getInstance(), MongoDb.getInstance());
         super.start();
 
         final EventBus eb = getEventBus(vertx);
@@ -104,6 +103,7 @@ public class Viescolaire extends BaseServer {
             throw new RuntimeException("no date in update-classes");
         }
 
+        DB.getInstance().init(Neo4j.getInstance(), Sql.getInstance(), MongoDb.getInstance());
 
         /*
 			DISPLAY CONTROLLER

--- a/src/main/java/fr/openent/viescolaire/controller/GroupeEnseignementController.java
+++ b/src/main/java/fr/openent/viescolaire/controller/GroupeEnseignementController.java
@@ -56,45 +56,6 @@ public class GroupeEnseignementController extends ControllerHelper {
         classeService = new DefaultClasseService();
     }
 
-    /**
-     * Liste les groupes d'enseignement d'un utilisateur
-     * @param request
-     */
-    @Get("/groupe/enseignement/user")
-    @ApiDoc("Liste les groupes d'enseignement d'un utilisateur")
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
-    public void getGroupesEnseignementUser(final HttpServerRequest request) {
-        UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
-            @Override
-            public void handle(final UserInfos user) {
-                if (user != null) {
-                    groupeService.listGroupesEnseignementsByUserId(user.getUserId(), new Handler<Either<String, JsonArray>>() {
-                        @Override
-                        public void handle(Either<String, JsonArray> event) {
-                            if(event.isRight()){
-                                JsonArray r = event.right().getValue();
-                                JsonObject groupeEnseignement, g;
-                                JsonArray groupesEnseignementJsonArray = new fr.wseduc.webutils.collections.JsonArray();
-
-                                for(int i = 0; i < r.size(); i++){
-                                    JsonObject o = r.getJsonObject(i);
-                                    g = o.getJsonObject("g");
-                                    groupeEnseignement = g.getJsonObject("data");
-                                    groupesEnseignementJsonArray.add(groupeEnseignement);
-                                }
-
-                                Renders.renderJson(request, groupesEnseignementJsonArray);
-                            }else{
-                                leftToResponse(request, event.left());
-                            }
-                        }
-                    });
-                } else {
-                    unauthorized(request);
-                }
-            }
-        });
-    }
 
     /**
      * Liste les groupes d'enseignement d'un utilisateur
@@ -126,20 +87,6 @@ public class GroupeEnseignementController extends ControllerHelper {
         });
     }
 
-    /**
-     * get name of groupe or classe
-     * @param request
-     */
-    @Get("/class/group/:groupId")
-    @ApiDoc("get the name of a groupe or classe ")
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
-    public void getNameOfGroupeClasse(final HttpServerRequest request) {
-
-        String idGroupe = request.params().get("groupId");
-        Handler<Either<String, JsonArray>> handler = arrayResponseHandler(request);
-
-        groupeService.getNameOfGroupeClasse(idGroupe, handler);
-    }
 
     /**
      * get the groups from a class

--- a/src/main/java/fr/openent/viescolaire/controller/GroupeEnseignementController.java
+++ b/src/main/java/fr/openent/viescolaire/controller/GroupeEnseignementController.java
@@ -102,7 +102,8 @@ public class GroupeEnseignementController extends ControllerHelper {
      */
     @Get("/groupe/enseignement/users/:groupId")
     @ApiDoc("Liste les groupes dse utilisateurs d'un groupe d'enseignement")
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(StructureAdminPersonnalTeacherFromGroup.class)
     public void getGroupesEnseignementUsers(final HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
             @Override

--- a/src/main/java/fr/openent/viescolaire/core/constants/Field.java
+++ b/src/main/java/fr/openent/viescolaire/core/constants/Field.java
@@ -56,6 +56,7 @@ public class Field<id_groupes> {
     public static final String PROFILES = "profiles";
     public static final String TEACHER = "Teacher";
 
+    public static final String PERSONNEL = "Personnel";
     public static final String FIRSTNAME = "firstName";
     public static final String LASTNAME = "lastName";
     public static final String DISPLAYNAME = "displayName";
@@ -146,6 +147,7 @@ public class Field<id_groupes> {
     public static final String STUDENT_ID_LIST = "student_id_list";
     public static final String PERIOD_ID_CAMEL = "periodId";
     public static final String GROUP_IDS_CAMEL = "groupIds";
+    public static final String PROFILE_TYPE = "type";
 
     private Field() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/fr/openent/viescolaire/core/constants/Field.java
+++ b/src/main/java/fr/openent/viescolaire/core/constants/Field.java
@@ -125,7 +125,7 @@ public class Field<id_groupes> {
     public static final String PREPARED = "prepared";
     public static final String IDSAUDIENCE = "idsAudience";
     public static final String IDGROUP = "idGroupe";
-
+    public static final String IDGROUP_CAMEL = "idGroup";
     public static final String ACTIVE = "active";
     public static final String PICTURE_ID = "picture_id";
     public static final String PICTUREID = "pictureId";

--- a/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
+++ b/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
@@ -22,16 +22,16 @@ public class StructureAdminPersonnalTeacherFromGroup extends DBService implement
         String query = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {idGroup} RETURN DISTINCT s.id as structureId";
         JsonObject params = new JsonObject();
 
-        params.put("idGroup", idGroup);
+        params.put(Field.GROUP_ID_CAMEL, idGroup);
 
         neo4j.execute(query ,params, Neo4jResult.validResultHandler(either -> {
-            if (either.isLeft()) {
-                handler.handle(false);
+            if (either.right().getValue() != null && !either.right().getValue().isEmpty()) {
+                String structureId = either.right().getValue().getJsonObject(0).getString(Field.STRUCTUREID);
+                handler.handle(structureId != null && user.getStructures().contains(structureId) && (WorkflowActionUtils.hasRight(user, WorkflowActionUtils.ADMIN_RIGHT) ||
+                        Field.PERSONNEL.equals(user.getType()) || Field.TEACHER.equals(user.getType())));
                 return;
             }
-            String structureId = either.right().getValue().getJsonObject(0).getString("structureId");
-            handler.handle(structureId != null && user.getStructures().contains(structureId) && (WorkflowActionUtils.hasRight(user, WorkflowActionUtils.ADMIN_RIGHT) ||
-                    Field.PERSONNEL.equals(user.getType()) || Field.TEACHER.equals(user.getType())));
+            handler.handle(false);
         }));
     }
 }

--- a/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
+++ b/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
@@ -14,15 +14,15 @@ import org.entcore.common.user.UserInfos;
 public class StructureAdminPersonnalTeacherFromGroup extends DBService implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        String idGroup = request.params().get(Field.GROUP_ID_CAMEL);
-        if (idGroup == null || idGroup.trim().isEmpty()) {
+        String groupId = request.params().get(Field.GROUP_ID_CAMEL);
+        if (groupId == null || groupId.trim().isEmpty()) {
             handler.handle(false);
             return;
         }
-        String query = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {idGroup} RETURN DISTINCT s.id as structureId";
+        String query = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {groupId} RETURN DISTINCT s.id as structureId";
         JsonObject params = new JsonObject();
 
-        params.put(Field.GROUP_ID_CAMEL, idGroup);
+        params.put(Field.GROUP_ID_CAMEL, groupId);
 
         neo4j.execute(query ,params, Neo4jResult.validResultHandler(either -> {
             if (either.right().getValue() != null && !either.right().getValue().isEmpty()) {

--- a/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
+++ b/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
@@ -1,17 +1,22 @@
 package fr.openent.viescolaire.security;
 
 import fr.openent.viescolaire.core.constants.Field;
-import fr.openent.viescolaire.db.DBService;
 import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.Neo4jResult;
 import org.entcore.common.user.UserInfos;
 
 
-public class StructureAdminPersonnalTeacherFromGroup extends DBService implements ResourcesProvider {
+public class StructureAdminPersonnalTeacherFromGroup implements ResourcesProvider {
+    private final Logger log = LoggerFactory.getLogger(StructureAdminPersonnalTeacherFromGroup.class);
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
         String groupId = request.params().get(Field.GROUP_ID_CAMEL);
@@ -19,19 +24,40 @@ public class StructureAdminPersonnalTeacherFromGroup extends DBService implement
             handler.handle(false);
             return;
         }
+
+        getStructureByGroup(groupId)
+                .onSuccess(structure -> {
+                    if (structure.isEmpty() && !structure.containsKey(Field.STRUCTUREID)){
+                        handler.handle(false);
+                        return;
+                    }
+                    String structureId = structure.getString(Field.STRUCTUREID, "");
+                    handler.handle(structureId != null && user.getStructures().contains(structureId)
+                                    && (WorkflowActionUtils.hasRight(user, WorkflowActionUtils.ADMIN_RIGHT) ||
+                        Field.PERSONNEL.equals(user.getType()) || Field.TEACHER.equals(user.getType())));
+                })
+                .onFailure(err -> {
+                    handler.handle(false);
+                    log.error(String.format("[Viescolaire@%s::Authorize] : an error has occurred during the attempting" +
+                            "to authorize, %s", this.getClass().getSimpleName(), err.getMessage()));
+                });
+    }
+
+
+    public Future<JsonObject> getStructureByGroup(String groupId){
+        Promise<JsonObject> promise = Promise.promise();
         String query = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {groupId} RETURN DISTINCT s.id as structureId";
         JsonObject params = new JsonObject();
 
         params.put(Field.GROUP_ID_CAMEL, groupId);
 
-        neo4j.execute(query ,params, Neo4jResult.validResultHandler(either -> {
-            if (either.right().getValue() != null && !either.right().getValue().isEmpty()) {
-                String structureId = either.right().getValue().getJsonObject(0).getString(Field.STRUCTUREID);
-                handler.handle(structureId != null && user.getStructures().contains(structureId) && (WorkflowActionUtils.hasRight(user, WorkflowActionUtils.ADMIN_RIGHT) ||
-                        Field.PERSONNEL.equals(user.getType()) || Field.TEACHER.equals(user.getType())));
-                return;
-            }
-            handler.handle(false);
+        Neo4j.getInstance().execute(query ,params, Neo4jResult.validUniqueResultHandler(either -> {
+                  if(either.isLeft()) {
+                      promise.fail(either.left().getValue());
+                  } else {
+                      promise.complete(either.right().getValue());
+                  }
         }));
+        return promise.future();
     }
 }

--- a/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
+++ b/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
@@ -1,0 +1,37 @@
+package fr.openent.viescolaire.security;
+
+import fr.openent.viescolaire.core.constants.Field;
+import fr.openent.viescolaire.db.DBService;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.neo4j.Neo4jResult;
+import org.entcore.common.user.UserInfos;
+
+
+public class StructureAdminPersonnalTeacherFromGroup extends DBService implements ResourcesProvider {
+    @Override
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+        String idGroup = request.params().get(Field.GROUP_ID_CAMEL);
+        if (idGroup == null || idGroup.trim().isEmpty()) {
+            handler.handle(false);
+            return;
+        }
+        String query = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {idGroup} RETURN DISTINCT s.id as structureId";
+        JsonObject params = new JsonObject();
+
+        params.put("idGroup", idGroup);
+
+        neo4j.execute(query ,params, Neo4jResult.validResultHandler(either -> {
+            if (either.isLeft()) {
+                handler.handle(false);
+                return;
+            }
+            String structureId = either.right().getValue().getJsonObject(0).getString("structureId");
+            handler.handle(structureId != null && user.getStructures().contains(structureId) && (WorkflowActionUtils.hasRight(user, WorkflowActionUtils.ADMIN_RIGHT) ||
+                    Field.PERSONNEL.equals(user.getType()) || Field.TEACHER.equals(user.getType())));
+        }));
+    }
+}

--- a/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
+++ b/src/main/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroup.java
@@ -1,6 +1,7 @@
 package fr.openent.viescolaire.security;
 
 import fr.openent.viescolaire.core.constants.Field;
+import fr.openent.viescolaire.helper.FutureHelper;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -50,14 +51,7 @@ public class StructureAdminPersonnalTeacherFromGroup implements ResourcesProvide
         JsonObject params = new JsonObject();
 
         params.put(Field.GROUP_ID_CAMEL, groupId);
-
-        Neo4j.getInstance().execute(query ,params, Neo4jResult.validUniqueResultHandler(either -> {
-                  if(either.isLeft()) {
-                      promise.fail(either.left().getValue());
-                  } else {
-                      promise.complete(either.right().getValue());
-                  }
-        }));
+        Neo4j.getInstance().execute(query ,params, Neo4jResult.validUniqueResultHandler(FutureHelper.handlerEitherPromise(promise)));
         return promise.future();
     }
 }

--- a/src/main/java/fr/openent/viescolaire/service/impl/DefaultGroupeService.java
+++ b/src/main/java/fr/openent/viescolaire/service/impl/DefaultGroupeService.java
@@ -146,9 +146,9 @@ public class DefaultGroupeService extends SqlCrudService implements GroupeServic
 
         // Format de retour des données
         StringBuilder RETURNING = new StringBuilder().append(" RETURN DISTINCT users.lastName as lastName, ")
-                .append(" users.firstName as firstName, users.id as id, users.deleteDate as deleteDate, ")
-                .append(" users.login as login, users.activationCode as activationCode, users.birthDate as birthDate, ")
-                .append(" users.blocked as blocked, users.source as source, c.name as className, c.id as classId ORDER")
+                .append(" users.firstName as firstName, users.id as id, ")
+                .append(" users.deleteDate as deleteDate, users.birthDate as birthDate, ")
+                .append(" c.name as className, c.id as classId ORDER")
                 .append(" BY lastName, firstName ");
 
         if (!StringUtils.isEmpty(profile)) {

--- a/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
+++ b/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
@@ -1,7 +1,6 @@
 package fr.openent.viescolaire.security;
 
 import fr.openent.viescolaire.core.constants.Field;
-import fr.openent.viescolaire.db.DB;
 import org.entcore.common.neo4j.Neo4jRest;
 import fr.wseduc.webutils.http.Binding;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -20,7 +19,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.FieldSetter;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
@@ -36,7 +34,6 @@ public class StructureAdminPersonnalTeacherFromGroupTest {
     Binding binding;
     MultiMap params;
     UserInfos user;
-//    Neo4j neo4j = Mockito.mock(Neo4j.class);
     private final Neo4j neo4j = Neo4j.getInstance();
     private final Neo4jRest neo4jRest = Mockito.mock(Neo4jRest.class);
     String PROPER_QUERY;
@@ -45,7 +42,6 @@ public class StructureAdminPersonnalTeacherFromGroupTest {
 
     @Before
     public void setUp() throws NoSuchFieldException {
-//        DB.getInstance().init(neo4j, null, null);
         request = Mockito.mock(HttpServerRequest.class);
         binding = Mockito.mock(Binding.class);
         params = Mockito.spy(new HeadersAdaptor(new DefaultHttpHeaders()));

--- a/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
+++ b/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
@@ -2,6 +2,7 @@ package fr.openent.viescolaire.security;
 
 import fr.openent.viescolaire.core.constants.Field;
 import fr.openent.viescolaire.db.DB;
+import org.entcore.common.neo4j.Neo4jRest;
 import fr.wseduc.webutils.http.Binding;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.vertx.core.Handler;
@@ -17,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -34,14 +36,16 @@ public class StructureAdminPersonnalTeacherFromGroupTest {
     Binding binding;
     MultiMap params;
     UserInfos user;
-    Neo4j neo4j = Mockito.mock(Neo4j.class);
+//    Neo4j neo4j = Mockito.mock(Neo4j.class);
+    private final Neo4j neo4j = Neo4j.getInstance();
+    private final Neo4jRest neo4jRest = Mockito.mock(Neo4jRest.class);
     String PROPER_QUERY;
     String groupId;
     JsonObject queryParamObject;
 
     @Before
     public void setUp() throws NoSuchFieldException {
-        DB.getInstance().init(neo4j, null, null);
+//        DB.getInstance().init(neo4j, null, null);
         request = Mockito.mock(HttpServerRequest.class);
         binding = Mockito.mock(Binding.class);
         params = Mockito.spy(new HeadersAdaptor(new DefaultHttpHeaders()));
@@ -51,6 +55,7 @@ public class StructureAdminPersonnalTeacherFromGroupTest {
         groupId = "groupId";
         queryParamObject = new JsonObject();
         queryParamObject.put(Field.GROUP_ID_CAMEL, groupId);
+        FieldSetter.setField(neo4j, neo4j.getClass().getDeclaredField("database"), neo4jRest);
     }
 
     @Test
@@ -63,7 +68,7 @@ public class StructureAdminPersonnalTeacherFromGroupTest {
             ctx.assertEquals(query, PROPER_QUERY);
             ctx.assertEquals(queryParams,  queryParamObject);
             return null;
-        }).when(neo4j).execute(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+        }).when(neo4jRest).execute(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
         access.authorize(request, binding, user, null);
     }
 }

--- a/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
+++ b/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
@@ -1,0 +1,69 @@
+package fr.openent.viescolaire.security;
+
+import fr.openent.viescolaire.core.constants.Field;
+import fr.openent.viescolaire.db.DB;
+import fr.wseduc.webutils.http.Binding;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.HeadersAdaptor;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.List;
+
+@RunWith(PowerMockRunner.class) //Using the PowerMock runner
+@PowerMockRunnerDelegate(VertxUnitRunner.class) //And the Vertx runner
+@PrepareForTest({StructureAdminPersonnalTeacherFromGroup.class, Neo4j.class})
+public class StructureAdminPersonnalTeacherFromGroupTest {
+    StructureAdminPersonnalTeacherFromGroup access;
+    HttpServerRequest request;
+    Binding binding;
+    MultiMap params;
+    UserInfos user;
+    Neo4j neo4j = Mockito.mock(Neo4j.class);
+    String PROPER_QUERY;
+    String groupId;
+    JsonObject queryParamObject;
+
+    @Before
+    public void setUp() throws NoSuchFieldException {
+        DB.getInstance().init(neo4j, null, null);
+        request = Mockito.mock(HttpServerRequest.class);
+        binding = Mockito.mock(Binding.class);
+        params = Mockito.spy(new HeadersAdaptor(new DefaultHttpHeaders()));
+        user = new UserInfos();
+        access = new StructureAdminPersonnalTeacherFromGroup();
+        PROPER_QUERY = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {idGroup} RETURN DISTINCT s.id as structureId";
+        groupId = "groupId";
+        queryParamObject = new JsonObject();
+        queryParamObject.put("idGroup", groupId);
+    }
+
+    @Test
+    public void authorize_should_use_proper_query(TestContext ctx) {
+        params.set(Field.GROUP_ID_CAMEL, "groupId");
+        Mockito.doReturn(params).when(request).params();
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            String query = invocation.getArgument(0);
+            JsonObject queryParams = invocation.getArgument(1);
+            ctx.assertEquals(query, PROPER_QUERY);
+            ctx.assertEquals(queryParams,  queryParamObject);
+            return null;
+        }).when(neo4j).execute(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+        access.authorize(request, binding, user, null);
+    }
+}

--- a/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
+++ b/src/test/java/fr/openent/viescolaire/security/StructureAdminPersonnalTeacherFromGroupTest.java
@@ -47,15 +47,15 @@ public class StructureAdminPersonnalTeacherFromGroupTest {
         params = Mockito.spy(new HeadersAdaptor(new DefaultHttpHeaders()));
         user = new UserInfos();
         access = new StructureAdminPersonnalTeacherFromGroup();
-        PROPER_QUERY = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {idGroup} RETURN DISTINCT s.id as structureId";
+        PROPER_QUERY = "MATCH(s:Structure)<-[:DEPENDS]-(g:Group) WHERE g.id = {groupId} RETURN DISTINCT s.id as structureId";
         groupId = "groupId";
         queryParamObject = new JsonObject();
-        queryParamObject.put("idGroup", groupId);
+        queryParamObject.put(Field.GROUP_ID_CAMEL, groupId);
     }
 
     @Test
     public void authorize_should_use_proper_query(TestContext ctx) {
-        params.set(Field.GROUP_ID_CAMEL, "groupId");
+        params.set(Field.GROUP_ID_CAMEL, Field.GROUP_ID_CAMEL);
         Mockito.doReturn(params).when(request).params();
         Mockito.doAnswer((Answer<Void>) invocation -> {
             String query = invocation.getArgument(0);


### PR DESCRIPTION
## Describe your changes
- Create a new resource filter which checks the structure from the groupId in parameter
- Change the position of DB.getInstance().init(Neo4j.getInstance(), Sql.getInstance(), MongoDb.getInstance()) in Viescolaire.java
in order to access the instance of neo4j inside resourceProvider;
- Remove some sensitive informations of user in DefaultGroupService.
- Remove unused API (@Get("/groupe/enseignement/user") and @Get("/class/group/:groupId")).

## Checklist tests
Only one route to test :
- **@Get("/groupe/enseignement/users/:groupId")** => competences => saisies projets, then choose a period and a class to activate route
## Issue ticket number and link
[#MVS-108](https://jira.support-ent.fr/browse/MVS-108)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

