### PR TITLE
fix(security): #MVS-118 add resourceFilter on put /periodes in PeriodeController and remove unused API

### DIFF
--- a/src/main/java/fr/openent/viescolaire/controller/PeriodeController.java
+++ b/src/main/java/fr/openent/viescolaire/controller/PeriodeController.java
@@ -18,6 +18,7 @@
 package fr.openent.viescolaire.controller;
 
 import fr.openent.Viescolaire;
+import fr.openent.viescolaire.security.AdminRightStructure;
 import fr.openent.viescolaire.service.PeriodeService;
 import fr.openent.viescolaire.service.UtilsService;
 import fr.openent.viescolaire.service.impl.DefaultPeriodeService;
@@ -28,6 +29,7 @@ import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.http.Renders;
 import fr.wseduc.webutils.request.RequestUtils;
 import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
 import io.vertx.core.Handler;
@@ -92,7 +94,7 @@ public class PeriodeController extends ControllerHelper {
     }
 
     @Get("/periodes/eval")
-    @ApiDoc("Informe si les periodes passes en parametres possedent des evaluations")
+    @ApiDoc("Informe si les periodes passees en parametres possedent des evaluations")
     @SecuredAction(value="", type = ActionType.AUTHENTICATED)
     public void getPeriodesEval(final HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
@@ -116,7 +118,8 @@ public class PeriodeController extends ControllerHelper {
 
     @Put("/periodes")
     @ApiDoc("Met à jour des periodes")
-    @SecuredAction(value="", type = ActionType.AUTHENTICATED)
+    @SecuredAction(value="", type = ActionType.RESOURCE)
+    @ResourceFilter(AdminRightStructure.class)
     public void updatePeriodes(final HttpServerRequest request){
         UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
             @Override

--- a/src/main/java/fr/openent/viescolaire/controller/PeriodeController.java
+++ b/src/main/java/fr/openent/viescolaire/controller/PeriodeController.java
@@ -92,30 +92,7 @@ public class PeriodeController extends ControllerHelper {
             }
         });
     }
-
-    @Get("/periodes/eval")
-    @ApiDoc("Informe si les periodes passees en parametres possedent des evaluations")
-    @SecuredAction(value="", type = ActionType.AUTHENTICATED)
-    public void getPeriodesEval(final HttpServerRequest request) {
-        UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
-            @Override
-            public void handle(UserInfos user) {
-                if (user != null) {
-                    final String[] idClasses = request.params().getAll("idClasse").toArray(new String[0]);
-
-                    if (idClasses.length == 0) {
-                        badRequest(request);
-                        log.error("getPeriodesEval : incorrect parameter");
-                    }
-
-                    periodeService.checkEvalOnPeriode(idClasses, defaultResponseHandler(request));
-                } else {
-                    unauthorized(request);
-                }
-            }
-        });
-    }
-
+    
     @Put("/periodes")
     @ApiDoc("Met à jour des periodes")
     @SecuredAction(value="", type = ActionType.RESOURCE)

--- a/src/main/java/fr/openent/viescolaire/controller/PeriodeController.java
+++ b/src/main/java/fr/openent/viescolaire/controller/PeriodeController.java
@@ -92,7 +92,12 @@ public class PeriodeController extends ControllerHelper {
             }
         });
     }
-    
+
+
+    /**
+     * @param request
+     * @queryParam {idEtablissement} mandatory
+     */
     @Put("/periodes")
     @ApiDoc("Met à jour des periodes")
     @SecuredAction(value="", type = ActionType.RESOURCE)

--- a/src/main/resources/public/modules/viescolaire/models/personnel/Structure.ts
+++ b/src/main/resources/public/modules/viescolaire/models/personnel/Structure.ts
@@ -57,8 +57,7 @@ export class Structure extends DefaultStructure {
             PERIODE : {
                 synchronization: '/viescolaire/periodes?idEtablissement=' + this.id,
                 type: '/viescolaire/periodes/types',
-                update : '/viescolaire/periodes',
-                evalOnPeriode : '/viescolaire/periodes/eval?'
+                update : '/viescolaire/periodes?idEtablissement=' + this.id,
             },
             NIVEAU_COMPETENCES : {
                 synchronisation: '/competences/maitrise/level/' + this.id,
@@ -261,19 +260,6 @@ export class Structure extends DefaultStructure {
                     periodes = _.difference(periodes, classe.periodes.all);
                 });
                 resolve();
-            });
-        });
-    }
-
-    checkEval(idClasses):Promise<any> {
-        return new Promise((resolve, reject) => {
-            let url = this.api.PERIODE.evalOnPeriode;
-            _.each(idClasses, (idClasse, index) => {
-                url += "idClasse=" + idClasse;
-                if( index != idClasses.length - 1 ) url +='&' ;
-            });
-            http().getJson(url).done((boolean) => {
-                resolve(boolean.exist);
             });
         });
     }


### PR DESCRIPTION
## Describe your changes
- Add AdminRightStructure resourceFilter on put /services route.
- Add structureId in query param on front API
- Remove @Get("/periodes/eval") API and linked method checkEval in front
## Checklist tests
In viesscolaire, go to "Paramétrage des périodes" and change dates for a classroom
## Issue ticket number and link
[MVS-118](https://jira.support-ent.fr/browse/MVS-118)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

