### PR TITLE
fix(security): MA-1107 fix module activation

### DIFF
--- a/src/main/java/fr/openent/viescolaire/security/AdministratorRight.java
+++ b/src/main/java/fr/openent/viescolaire/security/AdministratorRight.java
@@ -14,7 +14,6 @@ public class AdministratorRight implements ResourcesProvider {
     public void authorize(HttpServerRequest resourceRequest, Binding binding, UserInfos user, Handler<Boolean> handler) {
         String structureId = WorkflowActionUtils.getParamStructure(resourceRequest);
         boolean allowViesco = WorkflowActionUtils.hasRight(user, WorkflowActions.ADMIN_RIGHT.toString());
-        boolean allowCompetences = WorkflowActionUtils.hasRight(user, WorkflowActions.COMPETENCES_ACCESS.toString());
-        handler.handle( structureId != null && user.getStructures().contains(structureId) && allowViesco && allowCompetences);
+        handler.handle( structureId != null && user.getStructures().contains(structureId) && allowViesco);
     }
 }

--- a/src/main/java/fr/openent/viescolaire/security/WorkflowActions.java
+++ b/src/main/java/fr/openent/viescolaire/security/WorkflowActions.java
@@ -21,8 +21,7 @@ import fr.openent.Viescolaire;
 
 public enum WorkflowActions {
     MANAGE_TROMBINOSCOPE(Viescolaire.MANAGE_TROMBINOSCOPE),
-    ADMIN_RIGHT("Viescolaire.view"),
-    COMPETENCES_ACCESS("competences.access");
+    ADMIN_RIGHT("Viescolaire.view");
 
 
     private final String actionName;


### PR DESCRIPTION
## Describe your changes
Fixed an issue where in vie-scolaire a competences right's were needed to activate any modules. 
Now vie-scolaire.view is the only right is needed.
## Checklist tests
Try to activate a module (presences for exemple) in vie-scolaire with and without competences.view right.

## Issue ticket number and link
[MA-1107](https://jira.support-ent.fr/browse/MA-1107)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

