### PR TITLE
fix(init-1D): #MVS-130 fix handling of creating new existing timeslots

### DIFF
--- a/src/main/java/fr/openent/viescolaire/model/InitForm/InitFormTimetable.java
+++ b/src/main/java/fr/openent/viescolaire/model/InitForm/InitFormTimetable.java
@@ -104,7 +104,7 @@ public class InitFormTimetable implements IModel<InitFormTimetable> {
 
             if (!lunchAdded) {
                 // Add morning timeslot
-                slots.add(new Timeslot(morningPrefix + (i + 1), currentTime, nextTime));
+                slots.add(new Timeslot(morningPrefix + (i + 2), currentTime, nextTime));
                 endOfMorning = nextTime;
             } else {
                 // Add afternoon timeslot


### PR DESCRIPTION
## Describe your changes

- when initializing timeslots, check whether created timeslots exists. If that is the case, ignore creating a new slotprofile but save it as default profile
- fixed slot prefix starting at M0 instead of M1.

## Checklist tests

## Issue ticket number and link

- check if initializing the structure override existing timeslot when it already exists
- check that the first morning timeslot is called "M1"

https://jira.support-ent.fr/browse/MVS-130

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

