### PR TITLE
fix(init-1D): #MVS-141 prevent nullpointer on init reset API

### DIFF
--- a/src/main/java/fr/openent/viescolaire/service/impl/DefaultInitService.java
+++ b/src/main/java/fr/openent/viescolaire/service/impl/DefaultInitService.java
@@ -402,7 +402,8 @@ public class DefaultInitService implements InitService {
                     promise.fail(fail);
                 })
                 .onSuccess(subject -> {
-                    this.resetCourses(structureId, subject.getId())
+
+                    this.resetCourses(structureId, subject != null ? subject.getId() : null)
                             .compose(res ->  this.servicesService.deleteServiceBySubjectId(structureId, subject.getId()))
                             .compose(res -> this.setInitializationStatus(structureId, false))
                             .onSuccess(res -> promise.complete())
@@ -421,12 +422,16 @@ public class DefaultInitService implements InitService {
     private Future<JsonObject> resetCourses(String structureId, String subjectId) {
         Promise<JsonObject> promise = Promise.promise();
 
-        JsonObject action = new JsonObject()
-                .put(Field.ACTION, "delete-courses-subject")
-                .put(Field.STRUCTUREID, structureId)
-                .put(Field.SUBJECTID, subjectId);
+        if (subjectId != null) {
+            JsonObject action = new JsonObject()
+                    .put(Field.ACTION, "delete-courses-subject")
+                    .put(Field.STRUCTUREID, structureId)
+                    .put(Field.SUBJECTID, subjectId);
 
-        eb.request(EDT_ADDRESS, action, MessageResponseHandler.messageJsonObjectHandler(FutureHelper.handlerEitherPromise(promise)));
+            eb.request(EDT_ADDRESS, action, MessageResponseHandler.messageJsonObjectHandler(FutureHelper.handlerEitherPromise(promise)));
+        } else {
+            promise.complete();
+        }
 
         return promise.future();
     }


### PR DESCRIPTION
## Describe your changes

- prevent call for deletion of courses with a null subject


Documentation for the reset process : https://confluence.support-ent.fr/pages/viewpage.action?pageId=158079056

## Checklist tests

- check if init reset is still behaving properly
- check if deleting the default init subject beforehand prevent the reset API from returning a response

## Issue ticket number and link

https://jira.support-ent.fr/browse/MVS-141

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

