### PR TITLE
fix(init-1D): #MA-1177 fix exclusions set init for others systems

### DIFF
--- a/src/main/java/fr/openent/viescolaire/core/constants/Field.java
+++ b/src/main/java/fr/openent/viescolaire/core/constants/Field.java
@@ -225,6 +225,10 @@ public class Field<id_groupes> {
 
     public static final String SETTINGS = "settings";
     public static final String ALLOW_MULTIPLE_SLOTS = "allow_multiple_slots";
+
+    //Holidays System
+    public static final String OTHER = "OTHER";
+    public static final String FRENCH = "FRENCH";
     private Field() {
         throw new IllegalStateException("Utility class");
     }

--- a/src/main/java/fr/openent/viescolaire/service/InitService.java
+++ b/src/main/java/fr/openent/viescolaire/service/InitService.java
@@ -36,7 +36,7 @@ public interface InitService {
 
     Future<JsonObject> initServices(String structureId, SubjectModel subject);
 
-    Future<JsonObject> initExclusionPeriod(String structureId, String zone);
+    Future<JsonObject> initExclusionPeriod(String structureId, InitFormHolidays holidaysForm);
 
     Future<JsonObject> initCourses(String structureId, String subjectId, String startDate, String endDate,
                                    InitFormTimetable timetable, List<Timeslot> timeslots, String userId);

--- a/src/main/java/fr/openent/viescolaire/service/impl/DefaultInitService.java
+++ b/src/main/java/fr/openent/viescolaire/service/impl/DefaultInitService.java
@@ -317,9 +317,15 @@ public class DefaultInitService implements InitService {
     }
 
     @Override
-    public Future<JsonObject> initExclusionPeriod(String structureId, String zone) {
+    public Future<JsonObject> initExclusionPeriod(String structureId, InitFormHolidays holidaysForm) {
         Promise<JsonObject> promise = Promise.promise();
 
+        if(!Field.FRENCH.equals(holidaysForm.getSystem())) {
+            promise.complete();
+            return promise.future();
+        }
+
+        String zone = holidaysForm.getZone();
         if (!"A".equals(zone) && !"B".equals(zone) && !"C".equals(zone)) {
            promise.complete();
         } else {

--- a/src/main/java/fr/openent/viescolaire/worker/InitWorker1D.java
+++ b/src/main/java/fr/openent/viescolaire/worker/InitWorker1D.java
@@ -68,7 +68,7 @@ public class InitWorker1D extends InitWorker {
     @Override
     protected Future<Void> initExclusionPeriods() {
         Promise<Void> promise = Promise.promise();
-        this.initService.initExclusionPeriod(this.structureId, this.form.getHolidays().getZone())
+        this.initService.initExclusionPeriod(this.structureId, this.form.getHolidays())
                         .onFailure(promise::fail)
                         .onSuccess(res -> promise.complete());
         return promise.future();

--- a/src/test/java/fr/openent/viescolaire/service/impl/DefaultInitServiceTest.java
+++ b/src/test/java/fr/openent/viescolaire/service/impl/DefaultInitServiceTest.java
@@ -1,8 +1,11 @@
 package fr.openent.viescolaire.service.impl;
 
+import fr.openent.viescolaire.core.constants.Field;
+import fr.openent.viescolaire.model.InitForm.InitFormHolidays;
 import fr.openent.viescolaire.service.*;
 import fr.wseduc.mongodb.*;
 import io.vertx.core.*;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.*;
 import io.vertx.ext.unit.*;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -14,6 +17,8 @@ import org.junit.runner.RunWith;
 import org.mockito.*;
 import org.mockito.stubbing.*;
 import org.powermock.reflect.*;
+
+import static fr.openent.Viescolaire.EDT_ADDRESS;
 
 @RunWith(VertxUnitRunner.class)
 public class DefaultInitServiceTest {
@@ -27,9 +32,13 @@ public class DefaultInitServiceTest {
 
     private static final String STRUCTURE_ID = "structureId";
 
+    private EventBus eb;
+
     @Before
     public void setUp() {
-        ServiceFactory serviceFactory = new ServiceFactory(Vertx.vertx().eventBus(), sql, neo4j, mongoDb, new JsonObject());
+        //Mock event bus with spy
+        this.eb = Mockito.spy(Vertx.vertx().eventBus());
+        ServiceFactory serviceFactory = new ServiceFactory(this.eb, sql, neo4j, mongoDb, new JsonObject());
         this.initService = new DefaultInitService(serviceFactory);
     }
 
@@ -56,4 +65,62 @@ public class DefaultInitServiceTest {
 
         Whitebox.invokeMethod(initService, "getInitializationStatus", STRUCTURE_ID);
     }
+
+    @Test
+    public void testInitExclusionPeriod_withOtherSystem(TestContext ctx) throws Exception {
+        InitFormHolidays holidaysForm = Mockito.mock(InitFormHolidays.class);
+        Mockito.when(holidaysForm.getSystem()).thenReturn(Field.OTHER);
+
+        //Check if eb was called
+        Mockito.verify(eb, Mockito.never()).request(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+        Mockito.verifyNoMoreInteractions(eb);
+
+        Future<JsonObject> result = Whitebox.invokeMethod(initService, "initExclusionPeriod", STRUCTURE_ID, holidaysForm);
+
+        result.onComplete(res -> {
+            ctx.assertTrue(res.succeeded());
+            ctx.assertNull(res.result());
+        });
+    }
+
+    @Test
+    public void testInitExclusionPeriod_withInvalidZone(TestContext ctx) throws Exception {
+        InitFormHolidays holidaysForm = Mockito.mock(InitFormHolidays.class);
+        Mockito.when(holidaysForm.getSystem()).thenReturn(Field.FRENCH);
+        Mockito.when(holidaysForm.getZone()).thenReturn("D");
+
+        //Check if eb was called
+        Mockito.verify(eb, Mockito.never()).request(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+        Mockito.verifyNoMoreInteractions(eb);
+
+        Future<JsonObject> result = Whitebox.invokeMethod(initService, "initExclusionPeriod", STRUCTURE_ID, holidaysForm);
+
+        result.onComplete(res -> {
+            ctx.assertTrue(res.succeeded());
+            ctx.assertNull(res.result());
+        });
+    }
+
+    @Test
+    public void testInitExclusionPeriod_withValideZoneAndSystem(TestContext ctx) throws Exception {
+        Async async = ctx.async();
+        InitFormHolidays holidaysForm = Mockito.mock(InitFormHolidays.class);
+        Mockito.when(holidaysForm.getSystem()).thenReturn(Field.FRENCH);
+        Mockito.when(holidaysForm.getZone()).thenReturn("A");
+
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            JsonObject action = invocation.getArgument(1);
+            ctx.assertEquals(action.getString(Field.ACTION), "init");
+            ctx.assertEquals(action.getString(Field.STRUCTUREID), STRUCTURE_ID);
+            ctx.assertEquals(action.getString(Field.ZONE), "A");
+            ctx.assertFalse(action.getBoolean(Field.INITSCHOOLYEAR));
+            async.complete();
+            return null;
+        }).when(this.eb).request(Mockito.eq(EDT_ADDRESS), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+
+        Whitebox.invokeMethod(initService, "initExclusionPeriod", STRUCTURE_ID, holidaysForm);
+
+        async.awaitSuccess(10000);
+    }
+
 }


### PR DESCRIPTION
## Describe your changes
Fixed an issue where exclusions were initialized as the French system even when another system was specified.
## Checklist tests
Initialize a structure with the holiday system set to 'other'.
Then check in "vie-scolaire". The exclusions set should not be set up.
## Issue ticket number and link
[MA-1177](https://jira.support-ent.fr/browse/MA-1177)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

