### PR TITLE
fix: #COCO-5124 name of student not show in exemption due to inconsitency in neo4j

### DIFF
--- a/src/main/java/fr/openent/viescolaire/service/impl/DefaultEleveService.java
+++ b/src/main/java/fr/openent/viescolaire/service/impl/DefaultEleveService.java
@@ -163,9 +163,7 @@ public class DefaultEleveService extends SqlCrudService implements EleveService 
         // Condition de récupération des noeuds
         StringBuilder condition = new StringBuilder()
                 .append(" WHERE ")
-                .append(" u.id IN {idEleves}")
-                .append(" AND c.externalId IN u.classes ")
-                .append(" AND s.externalId IN u.structures");
+                .append(" u.id IN {idEleves}");
 
         StringBuilder order = new StringBuilder()
                 .append(" ORDER BY lastName, firstName ");
@@ -174,8 +172,7 @@ public class DefaultEleveService extends SqlCrudService implements EleveService 
         JsonObject params = new JsonObject();
 
         // Récupération d'élèves non supprimés
-        query.append("MATCH (u:User {profiles:[\"Student\"]})-[:IN]->(:ProfileGroup)-[:DEPENDS]->")
-                .append("(s:Structure {id:{idStructure}}), (c:Class)-[b:BELONGS]->(s)  ")
+        query.append("MATCH (u:User {profiles:[\"Student\"]})-[:IN]->(:ProfileGroup)-[:DEPENDS]->(c:Class)-[b:BELONGS]->(s:Structure {id:{idStructure}}) ")
                 .append(condition)
                 .append(" with u, c, s")
                 .append(" OPTIONAL MATCH (f:FunctionalGroup)<-[i:IN]-(u) with  u, c, s, f")


### PR DESCRIPTION
## Describe your changes

The query that retrieves students’ names based on the structure performs a double check using the structure’s externalId and the user’s User.structures field.
In the case of this ticket, the structure’s externalId does not match, which can happen in situations involving AAF merges with CSV imports.
According to Loïc, this field is incorrectly populated and is not always reliable, so this condition has been removed since the relationship itself is sufficient to guarantee correct data.

## Checklist tests

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/COCO-5124

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

